### PR TITLE
Fix broken link to BountySource

### DIFF
--- a/_services/bountysource.md
+++ b/_services/bountysource.md
@@ -1,6 +1,6 @@
 ---
 title: BountySource
-homepage: https://bountysource.com
+homepage: https://www.bountysource.com
 layout: service
 business_models:
 - paid-support


### PR DESCRIPTION
The current link, w/o www, gives a Secure Connection Failed